### PR TITLE
Add lightweight Spring Boot app that publishes a hardcoded Kafka payment message

### DIFF
--- a/kafka-producer-bug-app/README.md
+++ b/kafka-producer-bug-app/README.md
@@ -1,0 +1,33 @@
+# kafka-producer-bug-app
+
+Lightweight Spring Boot app with a payment-mimic endpoint that sends a hardcoded Kafka message.
+
+## Run
+
+```bash
+cd kafka-producer-bug-app
+mvn spring-boot:run
+```
+
+## Call mock payment endpoint
+
+```bash
+curl -X POST http://localhost:8080/payments \
+  -H 'Content-Type: application/json' \
+  -d '{"paymentId":"test-1","amount":1200}'
+```
+
+Each call publishes this hardcoded Kafka message:
+
+```json
+{"paymentId":"pay-123","status":"APPROVED","source":"payment-endpoint-mock"}
+```
+
+## Config
+
+```bash
+export KAFKA_BOOTSTRAP_SERVERS=localhost:9092
+export KAFKA_TOPIC=payment-response-topic
+export KAFKA_KEY=payment-response
+export KAFKA_TIMEOUT_SECONDS=30
+```

--- a/kafka-producer-bug-app/pom.xml
+++ b/kafka-producer-bug-app/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.3.5</version>
+        <relativePath/>
+    </parent>
+
+    <groupId>com.example</groupId>
+    <artifactId>kafka-producer-bug-app</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>kafka-producer-bug-app</name>
+    <description>Lightweight app to mimic payment endpoint and publish Kafka event</description>
+
+    <properties>
+        <java.version>17</java.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.kafka</groupId>
+            <artifactId>spring-kafka</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/kafka-producer-bug-app/src/main/java/com/example/kafkabug/KafkaProducerBugApp.java
+++ b/kafka-producer-bug-app/src/main/java/com/example/kafkabug/KafkaProducerBugApp.java
@@ -1,0 +1,13 @@
+package com.example.kafkabug;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class KafkaProducerBugApp {
+
+	public static void main(String[] args) {
+		SpringApplication.run(KafkaProducerBugApp.class, args);
+	}
+
+}

--- a/kafka-producer-bug-app/src/main/java/com/example/kafkabug/PaymentController.java
+++ b/kafka-producer-bug-app/src/main/java/com/example/kafkabug/PaymentController.java
@@ -1,0 +1,31 @@
+package com.example.kafkabug;
+
+import java.util.Map;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/payments")
+public class PaymentController {
+
+	private final PaymentKafkaService paymentKafkaService;
+
+	public PaymentController(PaymentKafkaService paymentKafkaService) {
+		this.paymentKafkaService = paymentKafkaService;
+	}
+
+	@PostMapping
+	public ResponseEntity<Map<String, String>> createPayment(@RequestBody(required = false) String requestPayload)
+			throws Exception {
+		this.paymentKafkaService.sendHardcodedResponse();
+		return ResponseEntity.accepted().body(Map.of(
+				"status", "ACCEPTED",
+				"message", "Payment received and Kafka message sent",
+				"requestPayload", requestPayload == null ? "" : requestPayload));
+	}
+
+}

--- a/kafka-producer-bug-app/src/main/java/com/example/kafkabug/PaymentKafkaService.java
+++ b/kafka-producer-bug-app/src/main/java/com/example/kafkabug/PaymentKafkaService.java
@@ -1,0 +1,35 @@
+package com.example.kafkabug;
+
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PaymentKafkaService {
+
+	private static final String HARDCODED_KAFKA_RESPONSE =
+			"{\"paymentId\":\"pay-123\",\"status\":\"APPROVED\",\"source\":\"payment-endpoint-mock\"}";
+
+	private final KafkaTemplate<String, String> kafkaTemplate;
+
+	@Value("${app.kafka.topic}")
+	private String topic;
+
+	@Value("${app.kafka.key:payment-response}")
+	private String key;
+
+	@Value("${app.kafka.timeout-seconds:30}")
+	private long timeoutSeconds;
+
+	public PaymentKafkaService(KafkaTemplate<String, String> kafkaTemplate) {
+		this.kafkaTemplate = kafkaTemplate;
+	}
+
+	public void sendHardcodedResponse() throws Exception {
+		this.kafkaTemplate.send(this.topic, this.key, HARDCODED_KAFKA_RESPONSE)
+				.get(this.timeoutSeconds, TimeUnit.SECONDS);
+	}
+
+}

--- a/kafka-producer-bug-app/src/main/resources/application.yml
+++ b/kafka-producer-bug-app/src/main/resources/application.yml
@@ -1,0 +1,17 @@
+spring:
+  application:
+    name: kafka-producer-bug-app
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
+
+server:
+  port: ${SERVER_PORT:8080}
+
+app:
+  kafka:
+    topic: ${KAFKA_TOPIC:payment-response-topic}
+    key: ${KAFKA_KEY:payment-response}
+    timeout-seconds: ${KAFKA_TIMEOUT_SECONDS:30}


### PR DESCRIPTION
### Motivation

- Provide a minimal reproducible Spring Boot application that exposes a mock payment endpoint and publishes a hardcoded Kafka message for debugging and reproducing producer issues.
- Centralize configuration for Kafka connectivity and message behavior via `application.yml` and environment variables.

### Description

- Add a new Spring Boot application (`KafkaProducerBugApp`) with a REST controller at `POST /payments` implemented in `PaymentController` that delegates to `PaymentKafkaService`.
- Implement `PaymentKafkaService` which uses a `KafkaTemplate<String,String>` to send a hardcoded JSON response message and waits for the send future with a configurable timeout via `app.kafka.timeout-seconds`.
- Add `application.yml` to configure `spring.kafka.bootstrap-servers`, producer serializers, server port, and `app.kafka` properties, and include `pom.xml` with `spring-boot-starter-web`, `spring-kafka`, and `spring-boot-starter-test` dependencies.
- Add `README.md` with run instructions, example `curl` call to `POST /payments`, sample published JSON, and environment variable configuration examples.

### Testing

- No automated tests were added to this change and no test suite was executed as part of this rollout; the project includes `spring-boot-starter-test` if tests are added later.
- Basic manual run instructions are documented in `README.md` using `mvn spring-boot:run` and a `curl` example to verify endpoint behavior locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6232921648322ba7664b54bc3ceec)